### PR TITLE
Add basic Elementor WordPress theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# MedEnglish Theme
+
+This repository contains a minimal WordPress theme for [medenglish.space](https://medenglish.space). The theme is designed to work with the Elementor plugin so you can customize pages visually.
+
+## Installing the Theme
+
+1. Copy the `medenglish-theme` folder into the `wp-content/themes` directory of your WordPress installation.
+2. In the WordPress admin panel, go to **Appearance > Themes** and activate **MedEnglish Theme**.
+3. Install and activate the Elementor plugin from **Plugins > Add New**.
+
+## Customizing the Home Page
+
+The file `front-page.php` provides a simple layout with a hero section and three feature blocks. Edit this file or use Elementor to modify the design. To recreate the layout shown on <https://www.youware.com/project/ta165zxqf3>, open the WordPress editor with Elementor and replace the content blocks accordingly.
+
+## Developing
+
+You can edit the PHP templates and `style.css` to adjust fonts, colors, or layout. The theme only loads a minimal stylesheet, so most visual customization can be achieved using Elementor's page builder features.

--- a/medenglish-theme/footer.php
+++ b/medenglish-theme/footer.php
@@ -1,0 +1,8 @@
+<footer class="site-footer">
+    <div class="container">
+        <p>&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?></p>
+    </div>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/medenglish-theme/front-page.php
+++ b/medenglish-theme/front-page.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * Template for the site front page.
+ * Designed to be edited with Elementor.
+ */
+get_header();
+?>
+
+<section class="hero">
+    <div class="container">
+        <h1><?php bloginfo('name'); ?></h1>
+        <p><?php bloginfo('description'); ?></p>
+        <a class="cta" href="#contact">Записатись зараз</a>
+    </div>
+</section>
+
+<section class="features container">
+    <div class="feature">
+        <h3>Feature One</h3>
+        <p>Describe first feature of your courses.</p>
+    </div>
+    <div class="feature">
+        <h3>Feature Two</h3>
+        <p>Describe second feature of your courses.</p>
+    </div>
+    <div class="feature">
+        <h3>Feature Three</h3>
+        <p>Describe third feature of your courses.</p>
+    </div>
+</section>
+
+<?php if ( function_exists( 'elementor_theme_do_location' ) && elementor_theme_do_location( 'single' ) ) : ?>
+    <?php // Elementor will handle this location ?>
+<?php else : ?>
+    <section id="contact" class="container">
+        <h2>Contact Us</h2>
+        <p>Use Elementor form widget to collect inquiries.</p>
+    </section>
+<?php endif; ?>
+
+<?php get_footer(); ?>

--- a/medenglish-theme/functions.php
+++ b/medenglish-theme/functions.php
@@ -1,0 +1,13 @@
+<?php
+// Enqueue theme styles and scripts
+function medenglish_enqueue_scripts() {
+    wp_enqueue_style( 'medenglish-style', get_stylesheet_uri() );
+}
+add_action( 'wp_enqueue_scripts', 'medenglish_enqueue_scripts' );
+
+// Add support for Elementor locations
+function medenglish_theme_setup() {
+    add_theme_support( 'title-tag' );
+    add_theme_support( 'post-thumbnails' );
+}
+add_action( 'after_setup_theme', 'medenglish_theme_setup' );

--- a/medenglish-theme/header.php
+++ b/medenglish-theme/header.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?> >
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?> >
+<header class="site-header">
+    <div class="container">
+        <h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
+    </div>
+</header>

--- a/medenglish-theme/index.php
+++ b/medenglish-theme/index.php
@@ -1,0 +1,17 @@
+<?php
+// Fallback index file for theme
+get_header();
+?>
+
+<main id="primary" class="site-main">
+    <?php
+    if ( have_posts() ) {
+        while ( have_posts() ) {
+            the_post();
+            the_content();
+        }
+    }
+    ?>
+</main>
+
+<?php get_footer(); ?>

--- a/medenglish-theme/style.css
+++ b/medenglish-theme/style.css
@@ -1,0 +1,49 @@
+/*
+Theme Name: MedEnglish Theme
+Theme URI: https://medenglish.space
+Author: MedEnglish Team
+Description: Custom theme for medenglish.space. Built for Elementor.
+Version: 1.0
+*/
+
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+.hero {
+    background: #f0f4ff;
+    padding: 80px 0;
+    text-align: center;
+}
+.hero h1 {
+    font-size: 3rem;
+    margin: 0 0 20px;
+}
+.hero p {
+    font-size: 1.2rem;
+    margin: 0 0 30px;
+}
+.hero .cta {
+    background: #0073e6;
+    color: #fff;
+    padding: 12px 24px;
+    border-radius: 4px;
+    text-decoration: none;
+}
+.features {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+    padding: 60px 0;
+    background: #fff;
+}
+.features .feature {
+    flex: 0 0 30%;
+    margin-bottom: 40px;
+    text-align: center;
+}
+.features h3 {
+    margin-top: 15px;
+}


### PR DESCRIPTION
## Summary
- add `medenglish-theme` with minimal WordPress templates
- provide instructions for activating the theme and Elementor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68419a6a0678832c9668622d43777597